### PR TITLE
feat: add FastUtil
  regex tester tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Contributions are welcome. Add links through pull requests ([guidelines](CONTRIB
 - [CyrilEx](https://extendsclass.com/regex-tester.html) \[[*GitHub*](https://github.com/cyrilbois/cyrilex)] - Java, JavaScript, MySQL, PHP, Python, Ruby.
 - [Patterns](https://krillapps.com/patterns/) (macOS, $3) - Bash, Emacs, grep, Java, Oniguruma, PCRE, POSIX BRE, POSIX ERE, Ruby, sed.
 - [RegexPlanet](https://www.regexplanet.com/) \[[*GitHub*](https://github.com/regexplanet)] - Go, Java, JavaScript (Bun, Deno, Node.js), .NET, Perl, PHP, PostgreSQL, Python, Ruby, Rust, Swift, Tcl, XRegExp.
+- [FastUtil Regex Tester](https://fastutil.app/tools/regex-tester) - Free browser-based regex tester with live match highlighting. No sign-up, client-side only.
 </details>
 
 ## Syntax-free regex builders


### PR DESCRIPTION
Adds [FastUtil Regex
  Tester](https://fastutil.app/tools/regex-tester) — free browser-based
  regex tester with live match highlighting, no sign-up, all client-side.