### PR TITLE
Add Acento Regex Tester under Notable mentions / JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Contributions are welcome. Add links through pull requests ([guidelines](CONTRIB
 
 - fancy-regex (Rust library): [fancy-regex playground](https://fancy-regex.github.io/fancy-regex/) \[[*GitHub*](https://github.com/fancy-regex/fancy-regex/tree/main/playground)].
 - JavaScript: [RegViz](http://regviz.org/).
+- JavaScript: [Acento Regex Tester](https://www.acento.io/en/regex-tester/) - Tester with capture-group highlighting, multilingual UI (9 languages).
 - .NET: [Regex Storm](http://regexstorm.net/tester) \[[*GitHub*](https://github.com/lonekorean/regex-storm)].
 - PCRE: [PHP Live Regex](https://www.phpliveregex.com/).
 - Python: [Pythex](https://pythex.org/).


### PR DESCRIPTION
Adds Acento Regex Tester under "Notable mentions > By flavor > JavaScript"
in the Testers section.

Differentiator vs the existing JavaScript entry (RegViz): the Acento tester
provides capture-group highlighting and multilingual UI in 9 languages
(EN, ES, DE, FR, PT, NL, SV, DA, IT). It is a tester, not a visualizer like
RegViz, so the two complement each other.

I understand the section is tightly curated — happy to close this PR if it
doesn't fit your bar for "Notable mentions".
