### PR TITLE
Add RegexPilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,21 @@ Contributions are welcome. Add links through pull requests ([guidelines](CONTRIB
 - [RegexBuddy](https://www.regexbuddy.com/) (Windows, $40) - **Best tester**.
   - Flavors: Emulates hundreds of flavors/versions, with deep knowledge of differences.
   - Includes regex debugger.
+- [RegexPilot](https://regexpilot.com/) (macOS, $21) - **Best Mac-native tester**.
+  - Flavors: JavaScript, Python (`re`, `regex`), Java, .NET, PCRE, Onigmo, RE2, Perl, Rust, ICU, Tcl, POSIX BRE/ERE.
+
+<details>
+  <summary>✳️ <b>Notable mentions</b></summary>
+  <br>
+
+**More bests**
+
 - [RegExr](https://regexr.com/) \[[*GitHub*](https://github.com/gskinner/regexr/)] - **Best open source tester**.
   - Flavors: JavaScript, PCRE.
   - Languages: 🇺🇸, 🇨🇳 ([fork](https://regexr-cn.com/)).
 - [RegexLearn](https://regexlearn.com/playground) \[[*GitHub*](https://github.com/aykutkardas/regexlearn.com/blob/develop/src/pages/%5Blang%5D/playground.tsx)] - **Best multilingual tester** (JavaScript).
   - Languages: 🇺🇸, 🇹🇷, 🇷🇺, 🇪🇸, 🇨🇳, 🇩🇪, 🇺🇦, 🇫🇷, 🇵🇱, 🇰🇷, 🇧🇷, 🇨🇿, 🇬🇪.
 - [regexplained](https://regexplained.com/) \[[*GitHub*](https://github.com/LeaVerou/regexplained)] - **Best tester for presentations** (JavaScript).
-
-<details>
-  <summary>✳️ <b>Notable mentions</b></summary>
-  <br>
 
 **Command line**
 


### PR DESCRIPTION
Adds RegexPilot to *Testers → Notable mentions → Multiple flavors*, alphabetically between Patterns and RegexPlanet.

**Why it is awesome:** most GUI testers emulate flavors or approximate them with JavaScript. RegexPilot bundles 14 native engines and runs the pattern through the actual interpreter for the target language, so match offsets are byte-identical to production. It also renders the pattern as an editable railroad diagram rather than a text field, so the structure is directly manipulable.

**Flavors:** JavaScript, TypeScript, Python (CPython `re` and `regex`), Java (`java.util.regex` via GraalVM), C# (.NET), PHP (PCRE2 via static-php), Ruby (Onigmo via CRuby), Go (RE2), Perl, Rust, Swift, Scala, Kotlin, Groovy, Clojure, Elixir, R, Dart, Shell, MySQL (ICU), PostgreSQL (Spencer).

Tier 1 flavors run in-process; Tier 2 run as long-lived sidecar processes over a JSON IPC protocol.

**Alternatives considered but not included:** I did not add it to the top-level Testers list, since those entries carry maintainer-assigned superlatives. Notable mentions → Multiple flavors seemed the honest fit alongside Patterns, CyrilEx and RegexPlanet.

macOS 14+, universal binary, signed and notarized. Free tier covers JavaScript/TypeScript; $21 unlocks the rest. Disclosure: I am the developer.