### PR TITLE
Add Nutilz Regex Visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Contributions are welcome. Add links through pull requests ([guidelines](CONTRIB
 - [Regex Nodes](https://johannesvollmer.com/regex-nodes/) \[[*GitHub*](https://github.com/johannesvollmer/regex-nodes)] - Graphical editor with visual hierarchy. Flavor: JavaScript.
 - [Debuggex](https://www.debuggex.com/) - Create railroad diagrams. Flavors: JavaScript, PCRE, Python.
 - [Regexper](https://regexper.com/) \[[*GitLab*](https://gitlab.com/javallone/regexper-static)] - Create railroad diagrams. Flavor: JavaScript.
+- [Nutilz Regex Visualizer](https://nutilz.com/regex-visualizer) - Token-by-token visual breakdown paired with plain-English step-by-step explanations and live match/capture-group testing in one view. Flavor: JavaScript.
 </details>
 
 ## Grep-like tools


### PR DESCRIPTION
Adds [Nutilz Regex Visualizer](https://nutilz.com/regex-visualizer) as a Notable mention under Visualizers.

**Why it's useful:** it pairs a token-by-token visual breakdown of the pattern with a plain-English step-by-step explanation of each token, plus a live match tester that shows numbered and named capture groups for the current input. All three views (breakdown, explanation, match test) live in one page, which none of the three main Visualizers entries currently combine.

**Flavor:** JavaScript (native `RegExp`, ES2018+ features like named groups). Runs entirely client-side, no upload of patterns or test text.

**Alternatives considered:** Regex Vis / Regulex / Nodexr (main list) render true branching/looping railroad diagrams, which this tool does not attempt — its diagram is a linear token breakdown, not a syntax diagram, so I'm proposing it for Notable mentions rather than the main list. Debuggex is the closest existing comparable (diagram + live testing) but is multi-flavor and does not include the step-by-step plain-English explanation.

Free, no signup required.