### PR TITLE
Add PortalToolsGO to JavaScript testers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Contributions are welcome. Add links through pull requests ([guidelines](CONTRIB
 **By flavor**
 
 - fancy-regex (Rust library): [fancy-regex playground](https://fancy-regex.github.io/fancy-regex/) \[[*GitHub*](https://github.com/fancy-regex/fancy-regex/tree/main/playground)].
-- JavaScript: [RegViz](http://regviz.org/).
+- JavaScript: [RegViz](http://regviz.org/), [PortalToolsGO](https://portaltoolsgo.com.br/devtools/testador-de-regex) (Portuguese UI, matching runs in a Web Worker with a kill-timeout against ReDoS).
 - .NET: [Regex Storm](http://regexstorm.net/tester) \[[*GitHub*](https://github.com/lonekorean/regex-storm)].
 - PCRE: [PHP Live Regex](https://www.phpliveregex.com/).
 - Python: [Pythex](https://pythex.org/).


### PR DESCRIPTION
Adds PortalToolsGO (https://portaltoolsgo.com.br/devtools/testador-de-regex) next to RegViz under JavaScript testers. Flavor: JavaScript, running in-browser. What's different from RegViz: token-by-token pattern explanation in Portuguese, plus matching runs inside a Web Worker with a kill-timeout so a catastrophic backtracking pattern can't freeze the tab. Considered but didn't add: regex101 and RegExr already cover the general/multi-flavor case better than we would.