### PR TITLE
Add Nutilz to JavaScript regex testers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Contributions are welcome. Add links through pull requests ([guidelines](CONTRIB
 **By flavor**
 
 - fancy-regex (Rust library): [fancy-regex playground](https://fancy-regex.github.io/fancy-regex/) \[[*GitHub*](https://github.com/fancy-regex/fancy-regex/tree/main/playground)].
-- JavaScript: [RegViz](http://regviz.org/).
+- JavaScript: [Nutilz](https://nutilz.com/regex-tester), [RegViz](http://regviz.org/).
 - .NET: [Regex Storm](http://regexstorm.net/tester) \[[*GitHub*](https://github.com/lonekorean/regex-storm)].
 - PCRE: [PHP Live Regex](https://www.phpliveregex.com/).
 - Python: [Pythex](https://pythex.org/).


### PR DESCRIPTION
Adds [Nutilz](https://nutilz.com/regex-tester) to the JavaScript regex testers in Notable mentions.

Nutilz Regex Tester is a free browser-based regular expression tester for JavaScript regex patterns with real-time match highlighting, capture group extraction, and live syntax validation. It runs entirely client-side without registration or tracking.