### PR TITLE
Add RegexTester.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Contributions are welcome. Add links through pull requests ([guidelines](CONTRIB
 
 - [CyrilEx](https://extendsclass.com/regex-tester.html) \[[*GitHub*](https://github.com/cyrilbois/cyrilex)] - Java, JavaScript, MySQL, PHP, Python, Ruby.
 - [Patterns](https://krillapps.com/patterns/) (macOS, $3) - Bash, Emacs, grep, Java, Oniguruma, PCRE, POSIX BRE, POSIX ERE, Ruby, sed.
+- [RegexTester.dev](https://regextester.dev/) - PCRE2, PCRE, JavaScript, Python, Go (RE2), Java, .NET, Rust.
 - [RegexPlanet](https://www.regexplanet.com/) \[[*GitHub*](https://github.com/regexplanet)] - Go, Java, JavaScript (Bun, Deno, Node.js), .NET, Perl, PHP, PostgreSQL, Python, Ruby, Rust, Swift, Tcl, XRegExp.
 </details>
 


### PR DESCRIPTION
Adds [RegexTester.dev](https://regextester.dev/) to the **Testers → Notable mentions → Multiple flavors** list.

**Why it's awesome:** a free, no-signup web-based tester that runs real WASM builds of eight regex engines in the browser (not simulations), so flavor behavior is exact — including engine-accurate behaviors like .NET's variable-length lookbehind or Go/RE2's non-backtracking semantics. It also provides a step-by-step pattern explainer, a 14k+ community pattern gallery, and an AI pattern generator that tests its output against the selected engine.

**Flavors:** PCRE2, PCRE, JavaScript, Python, Go (RE2), Java, .NET, Rust.

**Similar alternatives considered:** regex101 (multi-flavor, debugger), RegexPlanet (multi-flavor via server-side engines), CyrilEx (multi-flavor). RegexTester.dev complements these with fully client-side WASM engines and shareable permalinks.